### PR TITLE
remove unnecessary async wrapper

### DIFF
--- a/bip32-ed25519.ts
+++ b/bip32-ed25519.ts
@@ -171,7 +171,7 @@ export async function deriveChildNodePrivate(
  * @param g - Defines how many bits to zero in the left 32 bytes of the child key. Standard BIP32-ed25519 derivations use 32 bits. 
  * @returns - 64 bytes, being the 32 bytes of the child key (the new public key) followed by the 32 bytes of the chain code
  */
-export async function deriveChildNodePublic(extendedKey: Uint8Array, index: number, g: number = 9): Promise<Uint8Array> {
+export function deriveChildNodePublic(extendedKey: Uint8Array, index: number, g: number = 9): Uint8Array {
     if (index > 0x80000000) throw new Error('can not derive public key with harden')
 
     const pk: Buffer = Buffer.from(extendedKey.subarray(0, 32))

--- a/x.hd.wallet.api.crypto.spec.ts
+++ b/x.hd.wallet.api.crypto.spec.ts
@@ -512,7 +512,7 @@ describe("Contextual Derivation & Signing", () => {
                 // I'm provided with the wallet level m'/44'/283'/0'/0 root [public, chaincode]
                 // no private information is shared
                 // i can SOFTLY derive N public keys / addresses from this root
-                const derivedKey: Uint8Array = new Uint8Array(await deriveChildNodePublic(walletRoot, i, BIP32DerivationType.Peikert)) // g == 9
+                const derivedKey: Uint8Array = new Uint8Array(deriveChildNodePublic(walletRoot, i, BIP32DerivationType.Peikert)) // g == 9
             
                 // Deriving from my own wallet where i DO have private information
                 const myKey: Uint8Array = await cryptoService.keyGen(rootKey, KeyContext.Address, 0, i, BIP32DerivationType.Peikert)
@@ -531,7 +531,7 @@ describe("Contextual Derivation & Signing", () => {
 
             const numPublicKeysToDerive: number = 10
             for (let i = 0; i < numPublicKeysToDerive; i++) {                
-                const derivedKey: Uint8Array = new Uint8Array(await deriveChildNodePublic(walletRoot, i, BIP32DerivationType.Peikert)) // g == 9
+                const derivedKey: Uint8Array = new Uint8Array(deriveChildNodePublic(walletRoot, i, BIP32DerivationType.Peikert)) // g == 9
             
                 // Deriving from my own wallet where i DO have private information
                 const myKey: Uint8Array = await cryptoService.keyGen(rootKey, KeyContext.Address, 0, i, BIP32DerivationType.Peikert)


### PR DESCRIPTION
This removes an unnecessary `Promise` wrapper around `deriveChildNodePublic`. This method should be exposed as part of this API to facilitate creation of child addresses from an extended public key, and allowing it to be called synchronously is more versatile.