### PR TITLE
docs: clarify on CJS AFE-188

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ yarn test
 
 ## Regarding CJS
 
-This library can be used in a CommonJS as a dynamic import:
+This library can be used in a CommonJS environment as a dynamic import:
 
 ```ts
 ;(async function () {

--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ $ yarn
 $ yarn test
 ```
 
+## Regarding CJS
+
+This library can be used in a CommonJS as a dynamic import:
+
+```ts
+;(async function () {
+  const hd = await import("@algorandfoundation/xhd-wallet-api");
+})();
+```
+
+Make sure to set your tsconfig.json so it is at least:
+
+```json
+{
+  "target": "es2020",
+  "module": "Node16",
+  "moduleResolution": "Node16"
+}
+```
+
+# Test
+
 ## Output
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -2,12 +2,8 @@
   "name": "@algorandfoundation/xhd-wallet-api",
   "version": "1.0.2",
   "description": "A Typescript implementation of Algorand ARC-52 extended hierarchical determinstic wallets.",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
-  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "tsc && tsc-alias -p tsconfig.json -f",


### PR DESCRIPTION
- Explicitly sets the main keyword, rather than relying on default under exports.
- Explains how to dynamically import xhd-wallet-api from within a CJS module. Have confirmed (using [npm-workspaces](https://github.com/algorandfoundation/npm-workspace/tree/main/examples/typescript-cjs) that it works.