### PR TITLE
feat!: options object for ECDH that supports curve25519 or ed25519

### DIFF
--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -397,12 +397,12 @@ describe("Contextual Derivation & Signing", () => {
                 const aliceKey: Uint8Array = await cryptoService.keyGen(aliceRootKey, KeyContext.Identity, 0, 0)
                 const bobKey: Uint8Array = await cryptoService.keyGen(bobRootKey, KeyContext.Identity, 0, 0)
 
-                const aliceSharedSecret: Uint8Array = await cryptoService.ECDH(aliceRootKey, KeyContext.Identity, 0, 0, bobKey, computeSharedBlake2bSecret(true))
-                const bobSharedSecret: Uint8Array = await cryptoService.ECDH(bobRootKey, KeyContext.Identity, 0, 0, aliceKey, computeSharedBlake2bSecret(false))
+                const aliceSharedSecret: Uint8Array = await cryptoService.ECDH({ rootKey: aliceRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: bobKey, ecdhCallback: computeSharedBlake2bSecret(true) })
+                const bobSharedSecret: Uint8Array = await cryptoService.ECDH({ rootKey: bobRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: aliceKey, ecdhCallback: computeSharedBlake2bSecret(false) })
                 expect(aliceSharedSecret).toEqual(bobSharedSecret)
 
-                const aliceSharedSecret2: Uint8Array = await cryptoService.ECDH(aliceRootKey, KeyContext.Identity, 0, 0, bobKey, computeSharedBlake2bSecret(false))
-                const bobSharedSecret2: Uint8Array = await cryptoService.ECDH(bobRootKey, KeyContext.Identity, 0, 0, aliceKey, computeSharedBlake2bSecret(true))
+                const aliceSharedSecret2: Uint8Array = await cryptoService.ECDH({ rootKey: aliceRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: bobKey, ecdhCallback: computeSharedBlake2bSecret(false) })
+                const bobSharedSecret2: Uint8Array = await cryptoService.ECDH({ rootKey: bobRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: aliceKey, ecdhCallback: computeSharedBlake2bSecret(true) })
                 expect(aliceSharedSecret2).toEqual(bobSharedSecret2)
                 expect(aliceSharedSecret2).not.toEqual(aliceSharedSecret)
 
@@ -412,7 +412,7 @@ describe("Contextual Derivation & Signing", () => {
                 const aliceKey: Uint8Array = await cryptoService.keyGen(aliceRootKey, KeyContext.Identity, 0, 0)
                 const bobEd25519Keypair = ed25519.keygen()
 
-                const aliceSharedSecret: Uint8Array = await cryptoService.ECDH(aliceRootKey, KeyContext.Identity, 0, 0, bobEd25519Keypair.publicKey)
+                const aliceSharedSecret: Uint8Array = await cryptoService.ECDH({ rootKey: aliceRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: bobEd25519Keypair.publicKey })
 
                 const bobMontgomerySk = ed25519.utils.toMontgomerySecret(bobEd25519Keypair.secretKey)
                 const aliceMontgomeryPk = ed25519.utils.toMontgomery(aliceKey)
@@ -425,8 +425,8 @@ describe("Contextual Derivation & Signing", () => {
                 const aliceKey: Uint8Array = await cryptoService.keyGen(aliceRootKey, KeyContext.Identity, 0, 0)
                 const bobKey: Uint8Array = await cryptoService.keyGen(bobRootKey, KeyContext.Identity, 0, 0)
 
-                const aliceSharedSecret: Uint8Array = await cryptoService.ECDH(aliceRootKey, KeyContext.Identity, 0, 0, bobKey, computeSharedBlake2bSecret(true))
-                const bobSharedSecret: Uint8Array = await cryptoService.ECDH(bobRootKey, KeyContext.Identity, 0, 0, aliceKey, computeSharedBlake2bSecret(false))
+                const aliceSharedSecret: Uint8Array = await cryptoService.ECDH({ rootKey: aliceRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: bobKey, ecdhCallback: computeSharedBlake2bSecret(true) })
+                const bobSharedSecret: Uint8Array = await cryptoService.ECDH({ rootKey: bobRootKey, context: KeyContext.Identity, account: 0, keyIndex: 0, otherPartyEd25519Pub: aliceKey, ecdhCallback: computeSharedBlake2bSecret(false) })
 
                 expect(aliceSharedSecret).toEqual(bobSharedSecret)
 

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -310,30 +310,30 @@ export class XHDWalletAPI {
     }
 
 
-/**
- * Function to perform ECDH against a provided ed25519 or curve25519 public key.
- *
- * ECDH reference link: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
- *
- * It creates a shared secret between two parties. Each party only needs to be aware of the other's public key.
- * This symmetric secret can be used to derive a symmetric key for encryption and decryption, creating a private channel between the two parties.
- *
- * # Safety
- *
- * Without a callback function, the ECDH shared point is NOT uniformly distributed. It is recommended to provide a callback function that derives a final shared secret from the shared point. This functionality should only be called without a callback if the caller is doing KDF themselves.
- *
- * @param options - ECDH options object
- * @param options.rootKey - root key in extended format (kL, kR, c). Should be 96 bytes long
- * @param options.context - context of the key (i.e Address, Identity)
- * @param options.account - account number. This value will be hardened as part of BIP44
- * @param options.keyIndex - key index. This value will be a SOFT derivation as part of BIP44.
- * @param options.ecdhCallback - callback function that receives the shared point and both public keys in curve25519 format, and returns the final shared secret. This is typically a KDF.
- * @param options.derivationType - BIP32 derivation type, defines if it's standard Ed25519 or Peikert's amendment to BIP32-Ed25519
- * @param options.otherPartyEd25519Pub - raw 32 byte ed25519 public key of the other party. This key will be converted to montgomery format (curve25519) internally.
- * @param options.otherPartyCurve25519Pub - raw 32 byte curve25519 public key of the other party. This key is used directly without conversion.
- * @returns - If no ecdhCallback is provided, it returns the raw shared point. Otherwise, it returns the result of the ecdhCallback function.
- */
-async ECDH(options: ECDHOptions): Promise<Uint8Array> {
+    /**
+     * Function to perform ECDH against a provided ed25519 or curve25519 public key.
+     *
+     * ECDH reference link: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
+     *
+     * It creates a shared secret between two parties. Each party only needs to be aware of the other's public key.
+     * This symmetric secret can be used to derive a symmetric key for encryption and decryption, creating a private channel between the two parties.
+     *
+     * # Safety
+     *
+     * Without a callback function, the ECDH shared point is NOT uniformly distributed. It is recommended to provide a callback function that derives a final shared secret from the shared point. This functionality should only be called without a callback if the caller is doing KDF themselves.
+     *
+     * @param options - ECDH options object
+     * @param options.rootKey - root key in extended format (kL, kR, c). Should be 96 bytes long
+     * @param options.context - context of the key (i.e Address, Identity)
+     * @param options.account - account number. This value will be hardened as part of BIP44
+     * @param options.keyIndex - key index. This value will be a SOFT derivation as part of BIP44.
+     * @param options.ecdhCallback - callback function that receives the shared point and both public keys in curve25519 format, and returns the final shared secret. This is typically a KDF.
+     * @param options.derivationType - BIP32 derivation type, defines if it's standard Ed25519 or Peikert's amendment to BIP32-Ed25519
+     * @param options.otherPartyEd25519Pub - raw 32 byte ed25519 public key of the other party. This key will be converted to montgomery format (curve25519) internally.
+     * @param options.otherPartyCurve25519Pub - raw 32 byte curve25519 public key of the other party. This key is used directly without conversion.
+     * @returns - If no ecdhCallback is provided, it returns the raw shared point. Otherwise, it returns the result of the ecdhCallback function.
+     */
+    async ECDH(options: ECDHOptions): Promise<Uint8Array> {
         const { rootKey, context, account, keyIndex, ecdhCallback, derivationType } = options 
 
         const bip44Path: number[] = GetBIP44PathFromContext(context, account, keyIndex)

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -311,7 +311,7 @@ export class XHDWalletAPI {
 
 
 /**
- * Function to perform ECDH against a provided ed25519 public key.
+ * Function to perform ECDH against a provided ed25519 or curve25519 public key.
  *
  * ECDH reference link: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
  *

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -36,6 +36,18 @@ export function computeSharedBlake2bSecret(meFirst: boolean): ECDHCallback {
     }
 }
 
+export type ECDHOptions = {
+  rootKey: Uint8Array;
+  context: KeyContext;
+  account: number;
+  keyIndex: number;
+  ecdhCallback?: ECDHCallback;
+  derivationType?: BIP32DerivationType;
+} & (
+  | { otherPartyEd25519Pub: Uint8Array }
+  | { otherPartyCurve25519Pub: Uint8Array }
+);
+
 export enum BIP32DerivationType {
     // standard Ed25519 bip32 derivations based of: https://acrobat.adobe.com/id/urn:aaid:sc:EU:04fe29b0-ea1a-478b-a886-9bb558a5242a
     // Defines 32 bits to be zeroed from each derived zL
@@ -298,28 +310,34 @@ export class XHDWalletAPI {
     }
 
 
-    /**
-     * Function to perform ECDH against a provided ed25519 public key. 
-     *
-     * ECDH reference link: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
-     *
-     * It creates a shared secret between two parties. Each party only needs to be aware of the other's public key.
-     * This symmetric secret can be used to derive a symmetric key for encryption and decryption, creating a private channel between the two parties.
-     *
-     * # Safety
-     *
-     * Without a callback function, the ECDH shared point is NOT uniformly distributed. It is recommended to provide a callback function that derives a final shared secret from the shared point. This functionality should only be called without a callback if the caller is doing KDF themselves.
-     *
-     * @param context - context of the key (i.e Address, Identity)
-     * @param account - account number. This value will be hardened as part of BIP44
-     * @param keyIndex - key index. This value will be a SOFT derivation as part of BIP44.
-     * @param otherPartyEd25519Pub - raw 32 byte ed25519 public key of the other party. This key will be converted to montgomery format (curve25519) internally.
-     * @param ecdhCallback - callback function that receives the shared point and both public keys in curve25519 format, and returns the final shared secret. This is typically a KDF.
-     * @returns - If no ecdhCallback is provided, it returns the raw shared point. Otherwise, it returns the result of the ecdhCallback function. 
-     */
-    async ECDH(rootKey: Uint8Array, context: KeyContext, account: number, keyIndex: number, otherPartyEd25519Pub: Uint8Array, ecdhCallback?: ECDHCallback, derivationType: BIP32DerivationType = BIP32DerivationType.Peikert): Promise<Uint8Array> {
+/**
+ * Function to perform ECDH against a provided ed25519 public key.
+ *
+ * ECDH reference link: https://en.wikipedia.org/wiki/Elliptic-curve_Diffie%E2%80%93Hellman
+ *
+ * It creates a shared secret between two parties. Each party only needs to be aware of the other's public key.
+ * This symmetric secret can be used to derive a symmetric key for encryption and decryption, creating a private channel between the two parties.
+ *
+ * # Safety
+ *
+ * Without a callback function, the ECDH shared point is NOT uniformly distributed. It is recommended to provide a callback function that derives a final shared secret from the shared point. This functionality should only be called without a callback if the caller is doing KDF themselves.
+ *
+ * @param options - ECDH options object
+ * @param options.rootKey - root key in extended format (kL, kR, c). Should be 96 bytes long
+ * @param options.context - context of the key (i.e Address, Identity)
+ * @param options.account - account number. This value will be hardened as part of BIP44
+ * @param options.keyIndex - key index. This value will be a SOFT derivation as part of BIP44.
+ * @param options.ecdhCallback - callback function that receives the shared point and both public keys in curve25519 format, and returns the final shared secret. This is typically a KDF.
+ * @param options.derivationType - BIP32 derivation type, defines if it's standard Ed25519 or Peikert's amendment to BIP32-Ed25519
+ * @param options.otherPartyEd25519Pub - raw 32 byte ed25519 public key of the other party. This key will be converted to montgomery format (curve25519) internally.
+ * @param options.otherPartyCurve25519Pub - raw 32 byte curve25519 public key of the other party. This key is used directly without conversion.
+ * @returns - If no ecdhCallback is provided, it returns the raw shared point. Otherwise, it returns the result of the ecdhCallback function.
+ */
+async ECDH(options: ECDHOptions): Promise<Uint8Array> {
+        const { rootKey, context, account, keyIndex, ecdhCallback, derivationType } = options 
+
         const bip44Path: number[] = GetBIP44PathFromContext(context, account, keyIndex)
-        const childKey: Uint8Array = await this.deriveKey(rootKey, bip44Path, true, derivationType)
+        const childKey: Uint8Array = await this.deriveKey(rootKey, bip44Path, true, derivationType ?? BIP32DerivationType.Peikert)
 
         const scalar: Uint8Array = childKey.slice(0, 32)
 
@@ -328,7 +346,13 @@ export class XHDWalletAPI {
 
         // convert from ed25519 to curve25519
         const ourPubCurve25519: Uint8Array = crypto_sign_ed25519_pk_to_curve25519(ourPub)
-        const otherPartyPubCurve25519: Uint8Array = crypto_sign_ed25519_pk_to_curve25519(otherPartyEd25519Pub)
+        let otherPartyPubCurve25519: Uint8Array
+
+        if ('otherPartyCurve25519Pub' in options) {
+            otherPartyPubCurve25519 = options.otherPartyCurve25519Pub
+        } else {
+            otherPartyPubCurve25519 = crypto_sign_ed25519_pk_to_curve25519(options.otherPartyEd25519Pub)
+        }
 
         // find common point
         const sharedPoint: Uint8Array = crypto_scalarmult(scalar, otherPartyPubCurve25519)


### PR DESCRIPTION
This PR is proposes a change to the ECDH function so that it can work with both ed25519 and curve25519 keys. 

# The Problem

Our ECDH function currently only works with ed25519 keys as input for the other party. This is problematic because the DH is actually done with curve25519 montgomery keys, thus there are protocols/standards that operate solely with curve25519 and not ed25519. Unfortunately, it is impossible to reliably go from curve25519 keys to ed25519 keys.

## Example

One example of a standard that uses x25519 is HPKE. HPKE is a standard that defines how suites for KEM, KDF, and AEAD are used for encrypting data. All of the existing standardized KEMs are x25519 and not ed25519: https://www.iana.org/assignments/hpke/hpke.xhtml

This means if we want to be interoperable with standard HPKE KEMs, we need to support working directly with x25519 keys. This would allow an xHD-derived account to do a key exchange with another x25519 public key, regardless if the other party knows about xHD or not. The alternative is we define our own non-standard KEM that uses ed25519 as the encapsulated key or require users to manually get the private scalar and perform ECDH. 

# Solution

That being said, it is nice to also support ed25519 since that is the key used on Algorand. This PR changes the ECDH function to take in an object with *either* a ed25519 key or a curve25519 key. 

Additionally, having an object just makes the usage a bit easier. For example, when I first used the ECDH function I was very confused on why I couldn't key exchange properly when I was giving it a curve25519 pub key. The object forces the user to acknowledge whether the other parties pubkey is ed25519 or curve25519