### PR TITLE
feat: expandedSign and expandedPrivateKeyToPublicKey

### DIFF
--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -219,8 +219,8 @@ describe("Contextual Derivation & Signing", () => {
                 const derivedPrivateKey = await cryptoService.deriveKey(rootKey, bip44Path, true, BIP32DerivationType.Peikert)
                 const extendedPrivateKey64 = derivedPrivateKey.slice(0, 64)
 
-                const signatureFrom64 = cryptoService.extendedSign(extendedPrivateKey64, message)
-                const signatureFrom96 = cryptoService.extendedSign(derivedPrivateKey, message)
+                const signatureFrom64 = cryptoService.expandedSign(extendedPrivateKey64, message)
+                const signatureFrom96 = cryptoService.expandedSign(derivedPrivateKey, message)
 
                 expect(signatureFrom64).toEqual(signatureFrom96)
             })
@@ -229,7 +229,7 @@ describe("Contextual Derivation & Signing", () => {
                 const invalidExtendedPrivateKey = new Uint8Array(randomBytes(63))
                 const message = new Uint8Array(randomBytes(32))
 
-                expect(() => cryptoService.extendedSign(invalidExtendedPrivateKey, message)).toThrow(
+                expect(() => cryptoService.expandedSign(invalidExtendedPrivateKey, message)).toThrow(
                     "Invalid extended private key length, should be either 64 or 96 bytes"
                 )
             })

--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -211,6 +211,30 @@ describe("Contextual Derivation & Signing", () => {
                 })
             })
 
+        describe("extendedSign", () => {
+            it("\(OK) 64-byte and 96-byte extended keys produce same signature", async () => {
+                const message = new Uint8Array(randomBytes(64))
+                const bip44Path = [harden(44), harden(283), harden(1), 0, 2]
+
+                const derivedPrivateKey = await cryptoService.deriveKey(rootKey, bip44Path, true, BIP32DerivationType.Peikert)
+                const extendedPrivateKey64 = derivedPrivateKey.slice(0, 64)
+
+                const signatureFrom64 = cryptoService.extendedSign(extendedPrivateKey64, message)
+                const signatureFrom96 = cryptoService.extendedSign(derivedPrivateKey, message)
+
+                expect(signatureFrom64).toEqual(signatureFrom96)
+            })
+
+            it("\(FAIL) Throws on invalid extended private key length", () => {
+                const invalidExtendedPrivateKey = new Uint8Array(randomBytes(63))
+                const message = new Uint8Array(randomBytes(32))
+
+                expect(() => cryptoService.extendedSign(invalidExtendedPrivateKey, message)).toThrow(
+                    "Invalid extended private key length, should be either 64 or 96 bytes"
+                )
+            })
+        })
+
         describe("Signing Typed Data", () => {
             it("\(OK) Sign authentication challenge of 32 bytes, encoded base64", async () => {
                 const challenge: Uint8Array = new Uint8Array(randomBytes(32))

--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -212,7 +212,7 @@ describe("Contextual Derivation & Signing", () => {
             })
 
         describe("expandedSign", () => {
-            it("\(OK) 64-byte and 96-byte extended keys produce same signature", async () => {
+            it("\(OK) 64-byte and 96-byte expanded keys produce same signature", async () => {
                 const message = new Uint8Array(randomBytes(64))
                 const bip44Path = [harden(44), harden(283), harden(1), 0, 2]
 
@@ -235,7 +235,7 @@ describe("Contextual Derivation & Signing", () => {
                 const message = new Uint8Array(randomBytes(32))
 
                 expect(() => cryptoService.expandedSign(invalidExtendedPrivateKey, message)).toThrow(
-                    "Invalid extended private key length, should be either 64 or 96 bytes"
+                    "Invalid expanded private key length, should be either 64 or 96 bytes"
                 )
             })
         })

--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -224,7 +224,8 @@ describe("Contextual Derivation & Signing", () => {
 
                 expect(signatureFrom64).toEqual(signatureFrom96)
 
-                const publicKey = await cryptoService.deriveKey(rootKey, bip44Path, true, BIP32DerivationType.Peikert)
+                const extendedPublicKey = await cryptoService.deriveKey(rootKey, bip44Path, false, BIP32DerivationType.Peikert)
+                const publicKey = extendedPublicKey.subarray(0, 32)
                 const isValid: boolean = await cryptoService.verifyWithPublicKey(signatureFrom64, message, publicKey)
                 expect(isValid).toBe(true) 
             })

--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -211,7 +211,7 @@ describe("Contextual Derivation & Signing", () => {
                 })
             })
 
-        describe("extendedSign", () => {
+        describe("expandedSign", () => {
             it("\(OK) 64-byte and 96-byte extended keys produce same signature", async () => {
                 const message = new Uint8Array(randomBytes(64))
                 const bip44Path = [harden(44), harden(283), harden(1), 0, 2]

--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -211,6 +211,32 @@ describe("Contextual Derivation & Signing", () => {
                 })
             })
 
+        describe("expandedPrivateKeyToPublicKey", () => {
+            it("\(OK) 64-byte and 96-byte expanded keys produce same public key", async () => {
+                const bip44Path = [harden(44), harden(283), harden(1), 0, 2]
+
+                const derivedPrivateKey = await cryptoService.deriveKey(rootKey, bip44Path, true, BIP32DerivationType.Peikert)
+                const extendedPrivateKey64 = derivedPrivateKey.slice(0, 64)
+
+                const publicKeyFrom64 = cryptoService.expandedPrivateKeyToPublicKey(extendedPrivateKey64)
+                const publicKeyFrom96 = cryptoService.expandedPrivateKeyToPublicKey(derivedPrivateKey)
+
+                expect(publicKeyFrom64).toEqual(publicKeyFrom96)
+
+                const extendedPublicKey = await cryptoService.deriveKey(rootKey, bip44Path, false, BIP32DerivationType.Peikert)
+                const expectedPublicKey = extendedPublicKey.subarray(0, 32)
+                expect(publicKeyFrom64).toEqual(expectedPublicKey)
+            })
+
+            it("\(FAIL) Throws on invalid expanded private key length", () => {
+                const invalidExpandedPrivateKey = new Uint8Array(randomBytes(63))
+
+                expect(() => cryptoService.expandedPrivateKeyToPublicKey(invalidExpandedPrivateKey)).toThrow(
+                    "Invalid expanded private key length, should be either 64 or 96 bytes"
+                )
+            })
+        })
+
         describe("expandedSign", () => {
             it("\(OK) 64-byte and 96-byte expanded keys produce same signature", async () => {
                 const message = new Uint8Array(randomBytes(64))

--- a/src/x.hd.wallet.api.crypto.spec.ts
+++ b/src/x.hd.wallet.api.crypto.spec.ts
@@ -223,6 +223,10 @@ describe("Contextual Derivation & Signing", () => {
                 const signatureFrom96 = cryptoService.expandedSign(derivedPrivateKey, message)
 
                 expect(signatureFrom64).toEqual(signatureFrom96)
+
+                const publicKey = await cryptoService.deriveKey(rootKey, bip44Path, true, BIP32DerivationType.Peikert)
+                const isValid: boolean = await cryptoService.verifyWithPublicKey(signatureFrom64, message, publicKey)
+                expect(isValid).toBe(true) 
             })
 
             it("\(FAIL) Throws on invalid extended private key length", () => {

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -124,7 +124,7 @@ export class XHDWalletAPI {
      *
      * Ref: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6
      *
-     * @param expandedPrivateKey - extended private key (scalar || prefix) used for signing, should be either
+     * @param expandedPrivateKey - expanded private key (scalar || prefix) used for signing, should be either
      * 64 bytes (scalar || prefix) or 96 bytes (scalar || prefix || chainCode) depending on the use case
      *
      * @param data - data to be signed in raw bytes

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -124,7 +124,7 @@ export class XHDWalletAPI {
      *
      * Ref: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6
      *
-     * @param expandedPrivateKey - extended private key (scalar || prefix) used for signing, should be either 
+     * @param expandedPrivateKey - extended private key (scalar || prefix) used for signing, should be either
      * 64 bytes (scalar || prefix) or 96 bytes (scalar || prefix || chainCode) depending on the use case
      *
      * @param data - data to be signed in raw bytes

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -124,11 +124,16 @@ export class XHDWalletAPI {
      *
      * Ref: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6
      *
-     * @param extendedPrivateKey - extended private key (scalar || prefix) used for signing, should be at least 64 bytes long
+     * @param extendedPrivateKey - extended private key (scalar || prefix) used for signing, should be either 
+     * 64 bytes (scalar || prefix) or 96 bytes (scalar || prefix || chainCode) depending on the use case
+     *
      * @param data - data to be signed in raw bytes
      * @returns signature holding R and S, totally 64 bytes
      */
-     extendedSign(extendedPrivateKey: Uint8Array, data: Uint8Array): Uint8Array {
+    extendedSign(extendedPrivateKey: Uint8Array, data: Uint8Array): Uint8Array {
+        if (extendedPrivateKey.length !== 64 && extendedPrivateKey.length !== 96) {
+            throw Error("Invalid extended private key length, should be either 64 or 96 bytes")
+        }
         const scalar: Uint8Array = extendedPrivateKey.slice(0, 32);
         const kR: Uint8Array = extendedPrivateKey.slice(32, 64);
 

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -119,6 +119,20 @@ export class XHDWalletAPI {
         return extendedKey.subarray(0, 32) // only public key
     }
 
+    /** Function to derive the public key from an expanded private key (scalar || prefix)
+     *
+     * @param expandedPrivateKey - expanded private key (scalar || prefix) used for signing, should be either
+     * 64 bytes (scalar || prefix) or 96 bytes (scalar || prefix || chainCode)
+     * @returns public key in raw bytes
+     */
+    expandedPrivateKeyToPublicKey(expandedPrivateKey: Uint8Array): Uint8Array {
+        if (expandedPrivateKey.length !== 64 && expandedPrivateKey.length !== 96) {
+            throw Error("Invalid expanded private key length, should be either 64 or 96 bytes")
+        }
+        const scalar: Uint8Array = expandedPrivateKey.slice(0, 32);
+        return crypto_scalarmult_ed25519_base_noclamp(scalar)
+    }
+
     /** Signing function that signs data with the provided expanded private key: scalar || prefix.
      * This function should only be used in cases where the caller has the derived private key but not the root key
      *

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -119,6 +119,37 @@ export class XHDWalletAPI {
         return extendedKey.subarray(0, 32) // only public key
     }
 
+    /** Signing function that signs data with the provided extended private key: scalar || prefix.
+     * This function should only be used in cases where the caller has the derived private key but not the root key
+     *
+     * Ref: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6
+     *
+     * @param extendedPrivateKey - extended private key (scalar || prefix) used for signing, should be at least 64 bytes long
+     * @param data - data to be signed in raw bytes
+     * @returns signature holding R and S, totally 64 bytes
+     */
+     extendedSign(extendedPrivateKey: Uint8Array, data: Uint8Array): Uint8Array {
+        const scalar: Uint8Array = extendedPrivateKey.slice(0, 32);
+        const kR: Uint8Array = extendedPrivateKey.slice(32, 64);
+
+        // \(1): pubKey = scalar * G (base point, no clamp)
+        const publicKey = crypto_scalarmult_ed25519_base_noclamp(scalar);
+
+        // \(2): h = hash(c || msg) mod q
+        const r = crypto_core_ed25519_scalar_reduce(crypto_hash_sha512(Buffer.concat([kR, data])))
+
+        // \(4):  R = r * G (base point, no clamp)
+        const R = crypto_scalarmult_ed25519_base_noclamp(r)
+
+        // h = hash(R || pubKey || msg) mod q
+        let h = crypto_core_ed25519_scalar_reduce(crypto_hash_sha512(Buffer.concat([R, publicKey, data])));
+
+        // \(5): S = (r + h * k) mod q
+        const S = crypto_core_ed25519_scalar_add(r, crypto_core_ed25519_scalar_mul(h, scalar))
+
+        return Buffer.concat([R, S]);
+    }
+
     /**
      * Raw Signing function called by signData and signTransaction
      *
@@ -137,25 +168,7 @@ export class XHDWalletAPI {
     private async rawSign(rootKey: Uint8Array, bip44Path: number[], data: Uint8Array, derivationType: BIP32DerivationType): Promise<Uint8Array> {
         const raw: Uint8Array = await this.deriveKey(rootKey, bip44Path, true, derivationType)
 
-        const scalar: Uint8Array = raw.slice(0, 32);
-        const kR: Uint8Array = raw.slice(32, 64);
-
-        // \(1): pubKey = scalar * G (base point, no clamp)
-        const publicKey = crypto_scalarmult_ed25519_base_noclamp(scalar);
-
-        // \(2): h = hash(c || msg) mod q
-        const r = crypto_core_ed25519_scalar_reduce(crypto_hash_sha512(Buffer.concat([kR, data])))
-
-        // \(4):  R = r * G (base point, no clamp)
-        const R = crypto_scalarmult_ed25519_base_noclamp(r)
-
-        // h = hash(R || pubKey || msg) mod q
-        let h = crypto_core_ed25519_scalar_reduce(crypto_hash_sha512(Buffer.concat([R, publicKey, data])));
-
-        // \(5): S = (r + h * k) mod q
-        const S = crypto_core_ed25519_scalar_add(r, crypto_core_ed25519_scalar_mul(h, scalar))
-
-        return Buffer.concat([R, S]);
+        return this.extendedSign(raw, data)
     }
 
     /**

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -132,7 +132,7 @@ export class XHDWalletAPI {
      */
     expandedSign(expandedPrivateKey: Uint8Array, data: Uint8Array): Uint8Array {
         if (expandedPrivateKey.length !== 64 && expandedPrivateKey.length !== 96) {
-            throw Error("Invalid extended private key length, should be either 64 or 96 bytes")
+            throw Error("Invalid expanded private key length, should be either 64 or 96 bytes")
         }
         const scalar: Uint8Array = expandedPrivateKey.slice(0, 32);
         const kR: Uint8Array = expandedPrivateKey.slice(32, 64);

--- a/src/x.hd.wallet.api.crypto.ts
+++ b/src/x.hd.wallet.api.crypto.ts
@@ -119,23 +119,23 @@ export class XHDWalletAPI {
         return extendedKey.subarray(0, 32) // only public key
     }
 
-    /** Signing function that signs data with the provided extended private key: scalar || prefix.
+    /** Signing function that signs data with the provided expanded private key: scalar || prefix.
      * This function should only be used in cases where the caller has the derived private key but not the root key
      *
      * Ref: https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.6
      *
-     * @param extendedPrivateKey - extended private key (scalar || prefix) used for signing, should be either 
+     * @param expandedPrivateKey - extended private key (scalar || prefix) used for signing, should be either 
      * 64 bytes (scalar || prefix) or 96 bytes (scalar || prefix || chainCode) depending on the use case
      *
      * @param data - data to be signed in raw bytes
      * @returns signature holding R and S, totally 64 bytes
      */
-    extendedSign(extendedPrivateKey: Uint8Array, data: Uint8Array): Uint8Array {
-        if (extendedPrivateKey.length !== 64 && extendedPrivateKey.length !== 96) {
+    expandedSign(expandedPrivateKey: Uint8Array, data: Uint8Array): Uint8Array {
+        if (expandedPrivateKey.length !== 64 && expandedPrivateKey.length !== 96) {
             throw Error("Invalid extended private key length, should be either 64 or 96 bytes")
         }
-        const scalar: Uint8Array = extendedPrivateKey.slice(0, 32);
-        const kR: Uint8Array = extendedPrivateKey.slice(32, 64);
+        const scalar: Uint8Array = expandedPrivateKey.slice(0, 32);
+        const kR: Uint8Array = expandedPrivateKey.slice(32, 64);
 
         // \(1): pubKey = scalar * G (base point, no clamp)
         const publicKey = crypto_scalarmult_ed25519_base_noclamp(scalar);
@@ -173,7 +173,7 @@ export class XHDWalletAPI {
     private async rawSign(rootKey: Uint8Array, bip44Path: number[], data: Uint8Array, derivationType: BIP32DerivationType): Promise<Uint8Array> {
         const raw: Uint8Array = await this.deriveKey(rootKey, bip44Path, true, derivationType)
 
-        return this.extendedSign(raw, data)
+        return this.expandedSign(raw, data)
     }
 
     /**


### PR DESCRIPTION
This function is needed if we want to support recovering a child account for signing without needing the root key. The main idea is that a child account can be exported from a wallet without having to expose the full root key. This signing function will work with either the expanded ed25519 key or the extended key

Related AlgoKit PR: https://github.com/algorandfoundation/algokit-utils-ts/pull/542